### PR TITLE
Fix for duplicated settings in caddyfile after install

### DIFF
--- a/TygerCaddy/hosts/caddyfile.py
+++ b/TygerCaddy/hosts/caddyfile.py
@@ -103,7 +103,7 @@ def generate_caddyfile():
     return True
 
 
-def generate_dash():
+def generate_dash(fmode='a+'):
     project = settings.BASE_DIR
     caddyfilepath = project + '/data/caddyfile.conf'
     config = Config.objects.get(pk=1)
@@ -116,7 +116,7 @@ def generate_dash():
                                                         'root ' + str(config.root_dir) + '\n' \
                                                         '} \n'
 
-    caddyfile = open(caddyfilepath, "a+")
+    caddyfile = open(caddyfilepath, fmode)
     caddyfile.write(block)
     caddyfile.close()
 

--- a/TygerCaddy/install/views.py
+++ b/TygerCaddy/install/views.py
@@ -53,7 +53,7 @@ class Index(View):
                             )
         new_config.save()
         generate_keyfile()
-        generate_dash()
+        generate_dash('w+')
 
         return redirect('login')
 


### PR DESCRIPTION
During install, make sure to overwrite the caddyfile when writing the dashboard config to avoid duplicated settings.